### PR TITLE
Removed superfluous code / loading of own string translations.

### DIFF
--- a/mo-cache.php
+++ b/mo-cache.php
@@ -36,8 +36,4 @@ register_activation_hook(__FILE__, __NAMESPACE__ . '\Schema::activate');
 register_deactivation_hook(__FILE__, __NAMESPACE__ . '\Schema::deactivate');
 register_uninstall_hook(__FILE__, __NAMESPACE__ . '\Schema::uninstall');
 
-add_action('plugins_loaded', __NAMESPACE__ . '\Plugin::loadTextdomain');
-add_action('init', __NAMESPACE__ . '\Plugin::init', 20);
-
-// Handles translations with object cache.
 add_filter('override_load_textdomain', __NAMESPACE__ . '\Plugin::override_load_textdomain', \PHP_INT_MAX, 3);

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -22,23 +22,10 @@ class Plugin {
   const L10N = self::PREFIX;
 
   /**
-   * @implements init.
-   */
-  public static function init() {
-  }
-
-  /**
-   * Loads the plugin textdomain.
-   */
-  public static function loadTextdomain() {
-    load_plugin_textdomain(static::L10N, FALSE, static::L10N . '/languages/');
-  }
-
-  /**
    * Overrides the textdomain loading to implement a object cache for it.
    *
    * This code is borrowed from wp-includes/l10n.php:load_textdomain().
-   * Unfortunately is not hookable enough so there is no chance to implement it.
+   * Unfortunately is not hookable enough so there is no chance to implement it
    * in a most proper way.
    *
    * @see load_textdomain()
@@ -54,7 +41,6 @@ class Plugin {
 
     if ($l10n_domain !== FALSE) {
       $l10n[$domain] = $l10n_domain;
-
       return TRUE;
     }
 


### PR DESCRIPTION
As a performance plugin, the code should not perform unnecessary new operations.

The loading appeared at the end of current Redis monitor logs (attached to https://app.asana.com/0/30156186242982/643232497146496/f)