### PR TITLE
Fixed mo cache items are not refreshed when files are changed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,3 @@ Check:
 
 For further documentation about object caching, check:
  - https://codex.wordpress.org/Class_Reference/WP_Object_Cache
-
-## How to update translations
-
-This plugin will cache your translations for 1 day. If you update any translation in your site you should clear your cache to force the new translations to be loaded:
- - You can flush your cache with your favorite [cache plugin](https://www.hostinger.com/tutorials/wordpress/how-to-clear-wordpress-cache).
- - Use `wp-cli` to do it more granular with [`wp cache delete`](https://developer.wordpress.org/cli/commands/cache/delete/) flushing only `override_load_textdomain` group.

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -50,9 +50,10 @@ class Plugin {
     global $l10n, $l10n_unloaded;
     $l10n_unloaded = (array) $l10n_unloaded;
 
-    $l10n_domain = \wp_cache_get($domain, __FUNCTION__);
+    $current_filemtime = filemtime($mofile);
+    $cached_filemtime = wp_cache_get($domain, __FUNCTION__ . ':filemtime');
 
-    if ($l10n_domain !== FALSE) {
+    if ($current_filemtime === $cached_filemtime && FALSE !== $l10n_domain = \wp_cache_get($domain, __FUNCTION__)) {
       $l10n[$domain] = $l10n_domain;
 
       return TRUE;
@@ -77,7 +78,8 @@ class Plugin {
     unset($l10n_unloaded[$domain]);
     $l10n[$domain] = &$mo;
 
-    \wp_cache_set($domain, $mo, __FUNCTION__, time() + 24 * 60 * 60);
+    wp_cache_set($domain, $mo, __FUNCTION__);
+    wp_cache_set($domain, $current_filemtime, __FUNCTION__ . ':filemtime');
 
     return TRUE;
   }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -49,8 +49,8 @@ class Plugin {
     $current_filemtime = filemtime($mofile);
     $cached_filemtime = wp_cache_get($domain, __FUNCTION__ . ':filemtime');
 
-    if ($current_filemtime === $cached_filemtime && FALSE !== $l10n_domain = wp_cache_get($domain, __FUNCTION__)) {
-      $l10n[$domain] = $l10n_domain;
+    if ($current_filemtime === $cached_filemtime && FALSE !== $cached_l10n_domain = wp_cache_get($domain, __FUNCTION__)) {
+      $l10n[$domain] = $cached_l10n_domain;
       return TRUE;
     }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -50,22 +50,20 @@ class Plugin {
     global $l10n, $l10n_unloaded;
     $l10n_unloaded = (array) $l10n_unloaded;
 
-    // Ensures the file name is the correct and that the file exists and it's
-    // readable. Otherwise skip cache usage.
-    \do_action('load_textdomain', $domain, $mofile);
-    $mofile = \apply_filters('load_textdomain_mofile', $mofile, $domain);
+    // The file can only be cached if it exists and is readable.
+    do_action('load_textdomain', $domain, $mofile);
+    $mofile = apply_filters('load_textdomain_mofile', $mofile, $domain);
 
     if (!is_readable($mofile)) {
       return FALSE;
     }
 
-    // Uses cached data only if the file's modification date is the same than
-    // the one cached.
+    // Only use the cached data if the file's modification date is still the same.
     $current_filemtime = filemtime($mofile);
     $cached_filemtime = wp_cache_get($domain, __FUNCTION__ . ':filemtime');
-    if ($current_filemtime === $cached_filemtime && FALSE !== $l10n_domain = \wp_cache_get($domain, __FUNCTION__)) {
-      $l10n[$domain] = $l10n_domain;
 
+    if ($current_filemtime === $cached_filemtime && FALSE !== $l10n_domain = wp_cache_get($domain, __FUNCTION__)) {
+      $l10n[$domain] = $l10n_domain;
       return TRUE;
     }
 
@@ -81,8 +79,8 @@ class Plugin {
     unset($l10n_unloaded[$domain]);
     $l10n[$domain] = &$mo;
 
-    wp_cache_set($domain, $mo, __FUNCTION__);
     wp_cache_set($domain, $current_filemtime, __FUNCTION__ . ':filemtime');
+    wp_cache_set($domain, $mo, __FUNCTION__);
 
     return TRUE;
   }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -50,20 +50,23 @@ class Plugin {
     global $l10n, $l10n_unloaded;
     $l10n_unloaded = (array) $l10n_unloaded;
 
-    $current_filemtime = filemtime($mofile);
-    $cached_filemtime = wp_cache_get($domain, __FUNCTION__ . ':filemtime');
-
-    if ($current_filemtime === $cached_filemtime && FALSE !== $l10n_domain = \wp_cache_get($domain, __FUNCTION__)) {
-      $l10n[$domain] = $l10n_domain;
-
-      return TRUE;
-    }
-
+    // Ensures the file name is the correct and that the file exists and it's
+    // readable. Otherwise skip cache usage.
     \do_action('load_textdomain', $domain, $mofile);
     $mofile = \apply_filters('load_textdomain_mofile', $mofile, $domain);
 
     if (!is_readable($mofile)) {
       return FALSE;
+    }
+
+    // Uses cached data only if the file's modification date is the same than
+    // the one cached.
+    $current_filemtime = filemtime($mofile);
+    $cached_filemtime = wp_cache_get($domain, __FUNCTION__ . ':filemtime');
+    if ($current_filemtime === $cached_filemtime && FALSE !== $l10n_domain = \wp_cache_get($domain, __FUNCTION__)) {
+      $l10n[$domain] = $l10n_domain;
+
+      return TRUE;
     }
 
     $mo = new \MO();


### PR DESCRIPTION
Problem
* Existing mo gettext string translation cache items are not refreshed when the source files are changed on disk.

Proposed solution
1. Track the file modification time of each file to automatically invalidate the cache items when the file on disk is changed.

Ticket: https://app.asana.com/0/354170587449545/38165718233010